### PR TITLE
Fixed MaxMetastoreSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ az spring gateway update \
 Create the identity service application
 
 ```shell
-az spring app create --name ${IDENTITY_SERVICE_APP} --instance-count 1 --memory 1Gi
+az spring app create --name ${IDENTITY_SERVICE_APP} --instance-count 1 --memory 1Gi --jvm-options='-XX:MaxMetaspaceSize=148644K'
 ```
 
 Bind the identity service to Application Configuration Service

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ Create an application for each service:
 ```shell
 az spring app create --name ${CART_SERVICE_APP} --instance-count 1 --memory 1Gi &
 az spring app create --name ${ORDER_SERVICE_APP} --instance-count 1 --memory 1Gi &
-az spring app create --name ${PAYMENT_SERVICE_APP} --instance-count 1 --memory 1Gi &
-az spring app create --name ${CATALOG_SERVICE_APP} --instance-count 1 --memory 1Gi &
+az spring app create --name ${PAYMENT_SERVICE_APP} --instance-count 1 --memory 1Gi --jvm-options='-XX:MaxMetaspaceSize=148644K' &
+az spring app create --name ${CATALOG_SERVICE_APP} --instance-count 1 --memory 1Gi --jvm-options='-XX:MaxMetaspaceSize=148644K' &
 az spring app create --name ${FRONTEND_APP} --instance-count 1 --memory 1Gi &
 wait
 ```


### PR DESCRIPTION
Payment and Catalog services fail to start with message "Terminating due to java.lang.OutOfMemoryError: Metaspace", raising the value of MaxMetaspaceSize fixes these errors