### PR TITLE
Change plan from tanzu-asc-ent-mtr to asa-ent-hr-mtr

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Accept the legal terms and privacy statements for the Enterprise tier.
 
 ```shell
 az provider register --namespace Microsoft.SaaS
-az term accept --publisher vmware-inc --product azure-spring-cloud-vmware-tanzu-2 --plan tanzu-asc-ent-mtr
+az term accept --publisher vmware-inc --product azure-spring-cloud-vmware-tanzu-2 --plan asa-ent-hr-mtr
 ```
 
 Create an instance of Azure Spring Apps Enterprise.


### PR DESCRIPTION
Going through workshop, at the step of accepting legal and privacy terms for Enterprise tier, the provided value `tanzu-asc-ent-mtr` for plan in command `az term accept` did not work. After providing the auto-suggested value `asa-ent-hr-mtr`, the command completed successfully. This PR is to update the command `az term accept` to use the auto-suggested value