### PR TITLE
Add Testcontainers samples

### DIFF
--- a/apps/acme-catalog/build.gradle
+++ b/apps/acme-catalog/build.gradle
@@ -34,12 +34,15 @@ dependencies {
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.testcontainers:postgresql'
+	testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 dependencyManagement {
 	imports {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 		mavenBom "com.azure.spring:spring-cloud-azure-dependencies:${springCloudAzureVersion}"
+		mavenBom "org.testcontainers:testcontainers-bom:1.17.3"
 	}
 }
 

--- a/apps/acme-catalog/build.gradle
+++ b/apps/acme-catalog/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.testcontainers:postgresql'
 	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'io.rest-assured:rest-assured'
 }
 
 dependencyManagement {

--- a/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/CatalogApplicationTests.java
+++ b/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/CatalogApplicationTests.java
@@ -59,7 +59,9 @@ class CatalogApplicationTests {
 
     @AfterAll
     static void afterAll() {
-        prometheus.stop();
+        if (prometheus != null) {
+            prometheus.stop();
+        }
     }
 
     @Test

--- a/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/CatalogApplicationTests.java
+++ b/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/CatalogApplicationTests.java
@@ -1,13 +1,58 @@
 package com.vmware.acme.catalog;
 
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
 class CatalogApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @LocalServerPort
+    private int serverPort;
+
+    @Container
+    private static final PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:14.4-alpine3.16");
+
+    @DynamicPropertySource
+    static void sqlserverProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @BeforeEach
+    void before() {
+        RestAssured.port = serverPort;
+    }
+
+    @Test
+    void listAllProducts() {
+        given()
+                .get("/products")
+                .then()
+                .assertThat()
+                .body("data.size()", equalTo(8));
+    }
+
+    @Test
+    void findProductById() {
+        given()
+                .get("/products/533445d-530e-4a76-9398-5d16713b827b")
+                .then()
+                .assertThat()
+                .body("data.description", equalTo("Magic Yoga Mat!"));
+    }
 
 }

--- a/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/CatalogApplicationTests.java
+++ b/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/CatalogApplicationTests.java
@@ -1,21 +1,32 @@
 package com.vmware.acme.catalog;
 
 import io.restassured.RestAssured;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"management.endpoints.web.exposure.include=*",
+                "management.metrics.export.prometheus.step=2s"})
+@AutoConfigureMetrics
 @Testcontainers
 class CatalogApplicationTests {
 
@@ -34,25 +45,66 @@ class CatalogApplicationTests {
 
     @BeforeEach
     void before() {
-        RestAssured.port = serverPort;
+        org.testcontainers.Testcontainers.exposeHostPorts(this.serverPort);
+        RestAssured.port = this.serverPort;
     }
 
     @Test
     void listAllProducts() {
-        given()
-                .get("/products")
-                .then()
-                .assertThat()
-                .body("data.size()", equalTo(8));
+        try (final GenericContainer prometheus = createPrometheus()) {
+            prometheus.start();
+            given()
+                    .get("/products")
+                    .then()
+                    .assertThat()
+                    .body("data.size()", equalTo(8));
+            checkMetric(prometheus, "/products");
+        }
     }
 
     @Test
     void findProductById() {
-        given()
-                .get("/products/533445d-530e-4a76-9398-5d16713b827b")
-                .then()
-                .assertThat()
-                .body("data.description", equalTo("Magic Yoga Mat!"));
+        try (final GenericContainer prometheus = createPrometheus()) {
+            prometheus.start();
+            given()
+                    .get("/products/533445d-530e-4a76-9398-5d16713b827b")
+                    .then()
+                    .assertThat()
+                    .body("data.description", equalTo("Magic Yoga Mat!"));
+            checkMetric(prometheus, "/products/{id}");
+        }
+    }
+
+    private GenericContainer createPrometheus() {
+        var config = String.format("scrape_configs:\n" +
+                "  - job_name: \"prometheus\"\n" +
+                "    scrape_interval: 2s\n" +
+                "    metrics_path: \"/actuator/prometheus\"\n" +
+                "    static_configs:\n" +
+                "      - targets: ['host.testcontainers.internal:%s']", this.serverPort);
+        return new GenericContainer<>("prom/prometheus:v2.37.0")
+                .withExposedPorts(9090)
+                .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server is ready to receive web requests.*$"))
+                .withAccessToHost(true)
+                .withCopyToContainer(Transferable.of(config), "/etc/prometheus/prometheus.yml");
+    }
+
+    private void checkMetric(GenericContainer prometheus, String path) {
+        var query = String.format("store_products_seconds_count{uri=\"%s\"}", path);
+        Awaitility.given().pollInterval(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(15))
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    given().baseUri("http://" + prometheus.getHost())
+                            .port(prometheus.getMappedPort(9090))
+                            .queryParams(Map.of("query", query))
+                            .get("/api/v1/query")
+                            .prettyPeek()
+                            .then()
+                            .assertThat()
+                            .statusCode(200)
+                            .body("data.result[0].value", hasItem("1"));
+                });
     }
 
 }

--- a/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/ProductRepositoryTests.java
+++ b/apps/acme-catalog/src/test/java/com/vmware/acme/catalog/ProductRepositoryTests.java
@@ -1,0 +1,50 @@
+package com.vmware.acme.catalog;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ProductRepositoryTests {
+
+    @Container
+    private static final PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:14.4-alpine3.16");
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @DynamicPropertySource
+    static void sqlserverProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Test
+    void findAll() {
+        var products = this.productRepository.findAll();
+        assertThat(products).hasSize(8);
+    }
+
+    @Test
+    void findById() {
+        var product = this.productRepository.findById("533445d-530e-4a76-9398-5d16713b827b");
+        assertThat(product).hasValueSatisfying(p -> {
+            assertThat(p.getDescription()).isEqualTo("Magic Yoga Mat!");
+            assertThat(p.getImageUrl1()).isEqualTo("/static/images/yogamat_square.jpg");
+            assertThat(p.getImageUrl2()).isEqualTo("/static/images/yogamat_thumb2.jpg");
+            assertThat(p.getImageUrl3()).isEqualTo("/static/images/yogamat_thumb3.jpg");
+        });
+    }
+
+}

--- a/apps/acme-catalog/src/test/resources/application.yaml
+++ b/apps/acme-catalog/src/test/resources/application.yaml
@@ -1,4 +1,0 @@
-spring:
-  jpa:
-    hibernate:
-      ddl-auto: create-drop

--- a/apps/acme-catalog/src/test/resources/logback-test.xml
+++ b/apps/acme-catalog/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+
+</configuration>


### PR DESCRIPTION
This PR adds Testcontainers to the `acme-catalog` Spring-Boot application. 
Specifically, we added `@SpringBootTest` to the project, which could be considered integration tests.
The tests in `ProductRepositoryTests` are very classic database tests, that run in the same process as the Spring-Boot application and interact with the repository object directly.
They launch a real PostgreSQL database using Testcontainers.

The tests in `CatalogApplicationTests` can be considered out-of-process tests, since they communicate with the application
over the wire and over its public REST-API. Furthermore, they also test the possible integration with Prometheus, which is instrumented by Testcontainers.

Those tests will automatically be executed as part of the existing GHA pipeline.

As further steps for the workshop we envision the following (but we need some help or additional discussion about how to best tackle this):
* Have an interactive section in the workshop, that encourages the user to add an additional endpoint to the `acme-catalog` (e.g. `/findByTags`), which can be developed in a test-driven nature, using Testcontainers
* Have a full local end-2-end test of the whole set of applications, potentially using Selenium (through `BrowserWebDriverContainer` with Testcontainers). For this we would like to learn how to best build the Docker images for all app, ideally locally as well. This tests could be their own Gradle subproject and run in a distinct GHA workflow step.