### PR TITLE
TLS configuration updates/fix.

### DIFF
--- a/tap/doc/TAPDeploy.md
+++ b/tap/doc/TAPDeploy.md
@@ -113,7 +113,7 @@ kubectl get authserver -n <workloadNamespace>
 ```
 
 Save the Issuer URI as you will need it in the `workload build` section.  Also, you may need to create a new entry in your DNS registrar for this URL; this will likely be
-necessary if you are NOT using wildcard records in your DNS registrar.
+necessary if you are NOT using wildcard records in your DNS registrar.  DNS is also required in order for the TLS certificate to be issued for the auth server.
 
 
 ### Redis Deployment

--- a/tap/ingress.yaml
+++ b/tap/ingress.yaml
@@ -1,5 +1,4 @@
 #@ load("@ytt:data", "data")
-
 ---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -23,10 +22,10 @@ kind: Certificate
 metadata:
   name: acme-fitness-cert
 spec:
-  commonName:  #@ 'acme-fitness.' + data.values.appDomainName
+  commonName: #@ 'acme-fitness.' + data.values.appDomainName
   dnsNames:
-  -  #@ 'acme-fitness.' + data.values.appDomainName
+    -  #@ 'acme-fitness.' + data.values.appDomainName
   issuerRef:
-    name: letsencrypt-prod
+    name: letsencrypt-acme-prod
     kind: ClusterIssuer
   secretName: acme-fitness-cert


### PR DESCRIPTION
Fixing issue with TLS configuration of the Ingress (HttpProxy) resource using the wrong CA issuer.
Updated doc to note that DNS should be configured for the AppSSO component in order for TLS configuration to work correctly.

@asaikali, please review.