### PR TITLE
Update application.yaml to remove the mongo client autoconfiguration

### DIFF
--- a/apps/acme-assist/src/main/resources/application.yaml
+++ b/apps/acme-assist/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 vectorstore: simple
 
 spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration          
   data:
     mongodb:
       uri: <>


### PR DESCRIPTION
Now the autoconfiguration of the mongo client will fail if no mongo db uri provided.